### PR TITLE
Refactor DB schema and DAOs for new income and user models

### DIFF
--- a/lib/Dao/sqlite/db_helper_sqlite.dart
+++ b/lib/Dao/sqlite/db_helper_sqlite.dart
@@ -1,8 +1,9 @@
-import 'package:pocket_union/domain/enum/category_host.dart';
-import 'package:pocket_union/domain/models/category.dart';
 import 'package:path/path.dart';
 import 'package:sqflite/sqflite.dart';
+import 'package:flutter/foundation.dart';
 
+/// Database manager siguiendo patrón Singleton
+/// Responsabilidad única: gestionar conexión y ciclo de vida de SQLite
 class DbSqlite {
   static const _dbName = "pocket_union.db";
   static const _dbVersion = 1;
@@ -10,118 +11,244 @@ class DbSqlite {
   static final DbSqlite instance = DbSqlite._internal();
   DbSqlite._internal();
 
-  static Database? _db;
+  Database? _db;
 
+  /// Getter lazy para la base de datos
   Future<Database> get database async {
     if (_db != null) return _db!;
     _db = await _initDB();
     return _db!;
   }
 
+  /// Inicialización de la base de datos
   Future<Database> _initDB() async {
-    final db = await openDatabase(
-      join(await getDatabasesPath(), _dbName),
-      version: _dbVersion,
-      onCreate: _onCreate,
-    );
-    await db.execute('PRAGMA foreign_keys = ON');
-    return db;
-  }
-
-  Future _onCreate(Database db, int version) async {
     try {
-      await db.execute('''
-      CREATE TABLE IF NOT EXISTS user(
-        id UUID PRIMARY KEY NOT NULL,
-        name TEXT NOT NULL,
-        balance NUMERIC NOT NULL,
-        inCloud INTEGER NOT NULL
-      );
-    ''');
-      await db.execute('''
-      CREATE TABLE IF NOT EXISTS category(
-        id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-        name TEXT NOT NULL,
-        icon NUMERIC NOT NULL,
-        inCloud INTEGER NOT NULL
-      );
-    ''');
-      await db.execute('''
-      CREATE TABLE IF NOT EXISTS payment(
-        id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-        name TEXT NOT NULL,
-        date TEXT NOT NULL,
-        description TEXT,
-        balance NUMERIC NOT NULL,
-        category INTEGER NOT NULL,
-        id_user INTEGER NOT NULL,
-        inCloud INTEGER NOT NULL,
-        FOREIGN KEY(category) REFERENCES
-        category(id),
-        FOREIGN KEY(id_user) REFERENCES
-        user(id)
-      );
-    ''');
+      final dbPath = await getDatabasesPath();
+      final path = join(dbPath, _dbName);
 
-      await db.insert(
-          'category',
-          Category(
-                  id: '',
-                  name: 'Comida',
-                  icon: "57946",
-                  inCloud: false,
-                  coupleId: '',
-                  createdAt: DateTime.now(),
-                  categoryHost: CategoryHost.expense)
-              .toMap());
-      await db.insert(
-          'category',
-          Category(
-                  id: '',
-                  name: 'Transporte',
-                  icon: "61379",
-                  inCloud: false,
-                  coupleId: '',
-                  createdAt: DateTime.now(),
-                  categoryHost: CategoryHost.expense)
-              .toMap());
-      await db.insert(
-          'category',
-          Category(
-                  id: '',
-                  name: 'Deudas',
-                  icon: "62303",
-                  inCloud: false,
-                  coupleId: '',
-                  createdAt: DateTime.now(),
-                  categoryHost: CategoryHost.expense)
-              .toMap());
+      debugPrint('📁 Inicializando DB en: $path');
 
-      await db.execute('''
-      CREATE TABLE IF NOT EXISTS revenue(
-        id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-        name TEXT NOT NULL,
-        date TEXT NOT NULL,
-        description TEXT,
-        balance NUMERIC NOT NULL,
-        category INTEGER NOT NULL,
-        inCloud INTEGER NOT NULL,
-        id_user INTEGER NOT NULL,
-        FOREIGN KEY(category) REFERENCES
-        category(id),
-        FOREIGN KEY(id_user) REFERENCES
-        user(id)
+      final db = await openDatabase(
+        path,
+        version: _dbVersion,
+        onCreate: _onCreate,
+        onUpgrade: _onUpgrade,
+        onConfigure: _onConfigure,
       );
-    ''');
+
+      return db;
     } catch (e) {
-      throw Exception("Ocurrio un error con la base de datos $e");
+      debugPrint('❌ Error inicializando DB: $e');
+      rethrow;
     }
   }
 
-  Future close() async {
+  /// Configuración antes de abrir la DB
+  Future _onConfigure(Database db) async {
+    // Habilitar foreign keys
+    await db.execute('PRAGMA foreign_keys = ON');
+    debugPrint('✅ Foreign keys habilitadas');
+  }
+
+  /// Crear schema inicial (v1)
+  Future _onCreate(Database db, int version) async {
+    debugPrint('🏗️  Creando schema v$version');
+
+    await db.transaction((txn) async {
+      // ========== TABLA: profile ==========
+      await txn.execute('''
+        CREATE TABLE profile (
+          id TEXT PRIMARY KEY,
+          full_name TEXT,
+          avatar_url TEXT,
+          updated_at TEXT,
+          user_balance INTEGER NOT NULL DEFAULT 0,  -- En centavos
+          last_sync TEXT
+        )
+      ''');
+
+      // ========== TABLA: couple ==========
+      await txn.execute('''
+        CREATE TABLE couple (
+          id TEXT PRIMARY KEY,
+          created_at TEXT NOT NULL,
+          user1_id TEXT,
+          user2_id TEXT,
+          is_usable TEXT NOT NULL DEFAULT 'WAITING',
+          FOREIGN KEY(user1_id) REFERENCES profile(id) ON DELETE SET NULL,
+          FOREIGN KEY(user2_id) REFERENCES profile(id) ON DELETE SET NULL
+        )
+      ''');
+
+      // ========== TABLA: category ==========
+      await txn.execute('''
+        CREATE TABLE category (
+          id TEXT PRIMARY KEY,
+          name TEXT NOT NULL,
+          couple_id TEXT NOT NULL,
+          icon TEXT,
+          short_description TEXT,
+          color TEXT,
+          created_at TEXT NOT NULL,
+          category_host TEXT NOT NULL CHECK(category_host IN ('INCOME', 'EXPENSE')),
+          -- Campos de sincronización
+          sync_status TEXT NOT NULL DEFAULT 'pending' CHECK(sync_status IN ('pending', 'synced', 'conflict')),
+          last_sync_at TEXT,
+          local_updated_at TEXT NOT NULL,
+          is_deleted INTEGER NOT NULL DEFAULT 0,
+          FOREIGN KEY(couple_id) REFERENCES couple(id) ON DELETE CASCADE
+        )
+      ''');
+
+      // Índices para queries frecuentes
+      await txn.execute('''
+        CREATE INDEX idx_category_couple_id ON category(couple_id)
+      ''');
+      await txn.execute('''
+        CREATE INDEX idx_category_sync_status ON category(sync_status)
+      ''');
+
+      // ========== TABLA: expense ==========
+      await txn.execute('''
+        CREATE TABLE expense (
+          id TEXT PRIMARY KEY,
+          couple_id TEXT NOT NULL,
+          amount INTEGER NOT NULL,  -- En centavos
+          description TEXT,
+          category_id TEXT,
+          transaction_date TEXT,
+          is_fixed INTEGER NOT NULL DEFAULT 0,
+          importance_level INTEGER NOT NULL DEFAULT 0 CHECK(importance_level >= 0 AND importance_level <= 5),
+          is_planed INTEGER NOT NULL DEFAULT 0,
+          created_at TEXT NOT NULL,
+          created_by TEXT NOT NULL,
+          name TEXT NOT NULL CHECK(length(name) <= 50),
+          -- Campos de sincronización
+          sync_status TEXT NOT NULL DEFAULT 'pending',
+          last_sync_at TEXT,
+          local_updated_at TEXT NOT NULL,
+          is_deleted INTEGER NOT NULL DEFAULT 0,
+          FOREIGN KEY(couple_id) REFERENCES couple(id) ON DELETE CASCADE,
+          FOREIGN KEY(category_id) REFERENCES category(id) ON DELETE SET NULL,
+          FOREIGN KEY(created_by) REFERENCES profile(id) ON DELETE CASCADE
+        )
+      ''');
+
+      await txn.execute('''
+        CREATE INDEX idx_expense_couple_id ON expense(couple_id)
+      ''');
+      await txn.execute('''
+        CREATE INDEX idx_expense_transaction_date ON expense(transaction_date)
+      ''');
+      await txn.execute('''
+        CREATE INDEX idx_expense_category_id ON expense(category_id)
+      ''');
+
+      // ========== TABLA: expense_share ==========
+      await txn.execute('''
+        CREATE TABLE expense_share (
+          id TEXT PRIMARY KEY,
+          created_at TEXT NOT NULL,
+          expense_id TEXT NOT NULL,
+          user_id TEXT NOT NULL,
+          share_percentage REAL NOT NULL CHECK(share_percentage >= 0 AND share_percentage <= 100),
+          sync_status TEXT NOT NULL DEFAULT 'pending',
+          FOREIGN KEY(expense_id) REFERENCES expense(id) ON DELETE CASCADE,
+          FOREIGN KEY(user_id) REFERENCES profile(id) ON DELETE CASCADE
+        )
+      ''');
+
+      // ========== TABLA: income ==========
+      await txn.execute('''
+        CREATE TABLE income (
+          id TEXT PRIMARY KEY,
+          couple_id TEXT,
+          amount INTEGER NOT NULL,  -- En centavos
+          description TEXT,
+          category_id TEXT NOT NULL,
+          transaction_date TEXT NOT NULL,
+          is_recurring INTEGER NOT NULL DEFAULT 0,
+          recurrence_interval TEXT,  -- JSON serializado
+          is_received INTEGER NOT NULL DEFAULT 1,
+          received_in TEXT,  -- JSON serializado
+          created_at TEXT NOT NULL,
+          name TEXT NOT NULL CHECK(length(name) < 100),
+          user_recipient_id TEXT NOT NULL,
+          -- Campos de sincronización
+          sync_status TEXT NOT NULL DEFAULT 'pending',
+          last_sync_at TEXT,
+          local_updated_at TEXT NOT NULL,
+          is_deleted INTEGER NOT NULL DEFAULT 0,
+          FOREIGN KEY(couple_id) REFERENCES couple(id) ON DELETE CASCADE,
+          FOREIGN KEY(category_id) REFERENCES category(id) ON DELETE RESTRICT,
+          FOREIGN KEY(user_recipient_id) REFERENCES profile(id) ON DELETE CASCADE
+        )
+      ''');
+
+      // ========== TABLA: goal ==========
+      await txn.execute('''
+        CREATE TABLE goal (
+          id TEXT PRIMARY KEY,
+          created_at TEXT NOT NULL,
+          couple_id TEXT NOT NULL,
+          name TEXT NOT NULL,
+          target_amount INTEGER NOT NULL,  -- En centavos
+          current_amount INTEGER DEFAULT 0,  -- En centavos
+          deadline TEXT,
+          description TEXT,
+          sync_status TEXT NOT NULL DEFAULT 'pending',
+          FOREIGN KEY(couple_id) REFERENCES couple(id) ON DELETE CASCADE
+        )
+      ''');
+
+      // ========== TABLA: goal_contribution ==========
+      await txn.execute('''
+        CREATE TABLE goal_contribution (
+          id TEXT PRIMARY KEY,
+          goal_id TEXT NOT NULL,
+          user_id TEXT NOT NULL,
+          amount INTEGER NOT NULL DEFAULT 0,
+          contribution_date TEXT,
+          created_at TEXT NOT NULL,
+          sync_status TEXT NOT NULL DEFAULT 'pending',
+          FOREIGN KEY(goal_id) REFERENCES goal(id) ON DELETE CASCADE,
+          FOREIGN KEY(user_id) REFERENCES profile(id) ON DELETE CASCADE
+        )
+      ''');
+
+      debugPrint('✅ Schema creado exitosamente');
+    });
+  }
+
+  /// Manejar migraciones de versiones
+  Future _onUpgrade(Database db, int oldVersion, int newVersion) async {
+    debugPrint('📦 Migrando DB de v$oldVersion a v$newVersion');
+
+    // Aquí irán las migraciones futuras
+    // if (oldVersion < 2) { await _migrateToV2(db); }
+    // if (oldVersion < 3) { await _migrateToV3(db); }
+  }
+
+  /// Cerrar conexión a la base de datos
+  Future<void> close() async {
+    if (_db != null) {
+      await _db!.close();
+      _db = null;
+      debugPrint('🔒 Base de datos cerrada');
+    }
+  }
+
+  /// Resetear base de datos (solo para desarrollo/testing)
+  Future<void> reset() async {
     if (_db != null) {
       await _db!.close();
       _db = null;
     }
+
+    final dbPath = await getDatabasesPath();
+    final path = join(dbPath, _dbName);
+    await deleteDatabase(path);
+
+    debugPrint('🗑️  Base de datos eliminada');
   }
 }

--- a/lib/Dao/sqlite/income_dao_sqlite.dart
+++ b/lib/Dao/sqlite/income_dao_sqlite.dart
@@ -1,14 +1,24 @@
 import 'package:pocket_union/Dao/sqlite/db_helper_sqlite.dart';
 import 'package:pocket_union/domain/models/income.dart';
+import 'package:pocket_union/dto/new_income_dto.dart';
 import 'package:sqflite/sqflite.dart';
+import 'package:uuid/uuid.dart';
 
-class RevenueDaoSqlite {
+class IncomeDaoSqlite {
   final DbSqlite dbHelper;
+  final _uuid = Uuid();
 
-  RevenueDaoSqlite({required this.dbHelper});
+  IncomeDaoSqlite({required this.dbHelper});
 
-  Future<int> insertRevenue(Income revenue) async {
+  Future<int> insertRevenue(NewIncomeDto revenueDto) async {
     final db = await dbHelper.database;
+    final revenue = Income(
+        id: _uuid.v4(),
+        name: revenueDto.name,
+        transactionDate: DateTime.now(),
+        amount: revenueDto.amount,
+        createdAt: DateTime.now(),
+        inCloud: false);
     int id = await db.insert('revenue', revenue.toMap(),
         conflictAlgorithm: ConflictAlgorithm.replace);
     return id;

--- a/lib/Dao/sqlite/user_dao_sqlite.dart
+++ b/lib/Dao/sqlite/user_dao_sqlite.dart
@@ -1,46 +1,31 @@
 import 'package:pocket_union/Dao/sqlite/db_helper_sqlite.dart';
 import 'package:pocket_union/domain/models/user.dart';
+import 'package:pocket_union/domain/port/feat/user_port.dart';
 import 'package:sqflite/sqflite.dart';
 
-class UserDaoSqlite {
+class UserDaoSqlite extends UserPort {
   final DbSqlite dbHelper;
 
-  UserDaoSqlite ({required this.dbHelper});
+  UserDaoSqlite({required this.dbHelper});
 
-  Future<int> insertUser(User user) async {
+  @override
+  Future upsertUser(User user) async {
     final db = await dbHelper.database;
-    int id =  await db.insert(
-        'user',
-        user.toMap(),
-        conflictAlgorithm: ConflictAlgorithm.replace,
+    await db.insert(
+      'profile',
+      user.toMap(),
+      conflictAlgorithm: ConflictAlgorithm.replace,
     );
-    return id;
-  }
-
-  Future<List<User>> getAllUsers() async{
-    final db = await dbHelper.database;
-    try {
-      final List<Map<String, dynamic>> maps = await db.query(
-          'user',
-          orderBy: 'name ASC'
-      );
-      return List.generate(maps.length, (int i) {
-        return User.fromMap(maps[i]);
-      });
-    }catch(e) {
-      throw Exception(e);
-    }
   }
 
   Future<User> getTheUser(int idUser) async {
     final db = await dbHelper.database;
 
     try {
-      final Map<String, dynamic> map = (await db.query(
-        'user'
-      )) as Map<String, dynamic>;
+      final Map<String, dynamic> map =
+          (await db.query('user')) as Map<String, dynamic>;
       return User.fromMap(map);
-    } catch(e) {
+    } catch (e) {
       throw Exception('Error al cargar el usuario');
     }
   }

--- a/lib/core/providers.dart
+++ b/lib/core/providers.dart
@@ -2,7 +2,7 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:pocket_union/Dao/sqlite/category_dao_sqlite.dart';
 import 'package:pocket_union/Dao/sqlite/db_helper_sqlite.dart';
-import 'package:pocket_union/Dao/sqlite/revenue_dao_sqlite.dart';
+import 'package:pocket_union/Dao/sqlite/income_dao_sqlite.dart';
 import 'package:pocket_union/Dao/sqlite/user_dao_sqlite.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -13,9 +13,9 @@ final sqliteDbProvider = Provider<DbSqlite>((ref) {
 });
 
 // RevenueDaoSqlite provider
-final revenueDaoProvider = Provider<RevenueDaoSqlite>((ref) {
+final revenueDaoProvider = Provider<IncomeDaoSqlite>((ref) {
   final dbHelper = ref.read(sqliteDbProvider);
-  return RevenueDaoSqlite(dbHelper: dbHelper);
+  return IncomeDaoSqlite(dbHelper: dbHelper);
 });
 
 // UserDaoSqlite provider
@@ -31,7 +31,8 @@ final categoryDaoProvider = Provider<CategoryDaoSqlite>((ref) {
 });
 
 // SharedPreferences provider with lazy initialization
-final sharedPreferencesProvider = FutureProvider<SharedPreferences>((ref) async {
+final sharedPreferencesProvider =
+    FutureProvider<SharedPreferences>((ref) async {
   return await SharedPreferences.getInstance();
 });
 
@@ -47,7 +48,7 @@ final dotEnvProvider = FutureProvider<DotEnv>((ref) async {
 final supabaseClientProvider = FutureProvider<SupabaseClient>((ref) async {
   // Asegurar que dotenv esté cargado
   await ref.watch(dotEnvProvider.future);
-  
+
   // Check if Supabase is already initialized to avoid exceptions.
   // FutureProvider caches results, but this safeguards against any edge cases
   // where Supabase.initialize() might be called from elsewhere in the app.
@@ -57,6 +58,6 @@ final supabaseClientProvider = FutureProvider<SupabaseClient>((ref) async {
       anonKey: dotenv.env['SUPABASE_ANON_KEY']!,
     );
   }
-  
+
   return Supabase.instance.client;
 });

--- a/lib/core/services/auth/auth_service.dart
+++ b/lib/core/services/auth/auth_service.dart
@@ -1,10 +1,13 @@
 import 'package:pocket_union/domain/port/auth/auth_port.dart';
 import 'package:pocket_union/dto/login_dto.dart';
+import 'package:pocket_union/dto/new_couple_dto.dart';
 import 'package:pocket_union/dto/register_dto.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:uuid/uuid.dart';
 
 class AuthService extends AuthPort {
   final SupabaseClient _supabaseClient;
+  final _uuid = Uuid();
 
   AuthService(this._supabaseClient);
 
@@ -18,7 +21,21 @@ class AuthService extends AuthPort {
 
   @override
   Future<AuthResponse> register(RegisterDto registerRequest) {
-    // TODO: implement register
+    String sa = _uuid.v4();
+    print(sa);
+
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<dynamic> acceptCouple(NewCoupleDto coupleDto) {
+    // TODO: implement acceptCouple
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<dynamic> logout(String email) {
+    // TODO: implement logout
     throw UnimplementedError();
   }
 }

--- a/lib/domain/enum/sync_status.dart
+++ b/lib/domain/enum/sync_status.dart
@@ -1,0 +1,17 @@
+enum SyncStatus {
+  pending('PENDING'),
+  synced('SYNCED'),
+  conflict('CONFLICT'),
+  deleted('DELETED');
+
+  final String value;
+
+  const SyncStatus(this.value);
+
+  static SyncStatus fromString(String value) {
+    return SyncStatus.values.firstWhere(
+      (e) => e.value == value,
+      orElse: () => SyncStatus.pending,
+    );
+  }
+}

--- a/lib/domain/models/category.dart
+++ b/lib/domain/models/category.dart
@@ -1,4 +1,5 @@
 import 'package:pocket_union/domain/enum/category_host.dart';
+import 'package:pocket_union/domain/enum/sync_status.dart';
 
 class Category {
   final String id;
@@ -9,7 +10,7 @@ class Category {
   String? color;
   final DateTime createdAt;
   final CategoryHost categoryHost;
-  bool inCloud;
+  SyncStatus syncStatus;
 
   Category({
     required this.id,
@@ -20,7 +21,7 @@ class Category {
     this.color,
     required this.createdAt,
     required this.categoryHost,
-    required this.inCloud,
+    required this.syncStatus,
   });
 
   Map<String, dynamic> toMap() {
@@ -33,22 +34,21 @@ class Category {
       'color': color,
       'created_at': createdAt.toIso8601String(),
       'category_host': categoryHost.value,
-      'inCloud': inCloud ? 1 : 0,
+      'sync_status': syncStatus
     };
   }
 
   factory Category.fromMap(Map<String, dynamic> map) {
     return Category(
-      id: map['id'],
-      coupleId: map['couple_id'],
-      name: map['name'],
-      icon: map['icon'],
-      shortDescription: map['short_description'],
-      color: map['color'],
-      createdAt: DateTime.parse(map['created_at']),
-      categoryHost: CategoryHost.fromString(map['category_host']),
-      inCloud: map['inCloud'] == 1,
-    );
+        id: map['id'],
+        coupleId: map['couple_id'],
+        name: map['name'],
+        icon: map['icon'],
+        shortDescription: map['short_description'],
+        color: map['color'],
+        createdAt: DateTime.parse(map['created_at']),
+        categoryHost: CategoryHost.fromString(map['category_host']),
+        syncStatus: map['sync_status']);
   }
 
   Map<String, dynamic> toJson() {
@@ -66,15 +66,14 @@ class Category {
 
   factory Category.fromJson(Map<String, dynamic> json) {
     return Category(
-      id: json['id'],
-      coupleId: json['couple_id'],
-      name: json['name'],
-      icon: json['icon'],
-      shortDescription: json['short_description'],
-      color: json['color'],
-      createdAt: DateTime.parse(json['created_at']),
-      categoryHost: CategoryHost.fromString(json['category_host']),
-      inCloud: json['inCloud'] == 1,
-    );
+        id: json['id'],
+        coupleId: json['couple_id'],
+        name: json['name'],
+        icon: json['icon'],
+        shortDescription: json['short_description'],
+        color: json['color'],
+        createdAt: DateTime.parse(json['created_at']),
+        categoryHost: CategoryHost.fromString(json['category_host']),
+        syncStatus: json['sync_status']);
   }
 }

--- a/lib/domain/port/auth/auth_port.dart
+++ b/lib/domain/port/auth/auth_port.dart
@@ -1,8 +1,11 @@
 import 'package:pocket_union/dto/login_dto.dart';
+import 'package:pocket_union/dto/new_couple_dto.dart';
 import 'package:pocket_union/dto/register_dto.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 abstract class AuthPort {
   Future<AuthResponse> login(LoginDto loginRequest);
   Future<AuthResponse> register(RegisterDto registerRequest);
+  Future logout(String email);
+  Future acceptCouple(NewCoupleDto coupleDto);
 }

--- a/lib/domain/port/feat/user_port.dart
+++ b/lib/domain/port/feat/user_port.dart
@@ -1,0 +1,5 @@
+import 'package:pocket_union/domain/models/user.dart';
+
+abstract class UserPort {
+  Future upsertUser(User user);
+}

--- a/lib/dto/new_user_dto.dart
+++ b/lib/dto/new_user_dto.dart
@@ -1,0 +1,7 @@
+class NewUserDto {
+  final String id;
+  final String fullName;
+  String? avatarUrl;
+
+  NewUserDto({required this.id, required this.fullName, this.avatarUrl});
+}

--- a/lib/ui/screens/auth/widgets/login_form.dart
+++ b/lib/ui/screens/auth/widgets/login_form.dart
@@ -15,6 +15,7 @@ class LoginForm extends StatefulWidget {
   final Color colorFocusBorderInput;
   final Color colorEnabledBorderInput;
   @override
+  // ignore: no_logic_in_create_state
   State<LoginForm> createState() => _LoginFormState(
       colorEnabledBorderInput: colorEnabledBorderInput,
       colorFocusBorderInput: colorFocusBorderInput);
@@ -48,10 +49,10 @@ class _LoginFormState extends State<LoginForm> {
       if (mounted) {
         Navigator.pushReplacementNamed(context, AppRoutes.home);
         // context.showSnackBar('Check your email for a login link!');
-        print("Revisa email");
+        debugPrint("Revisa email");
       }
     } on AuthException catch (error) {
-      if (mounted) print(error.message);
+      if (mounted) debugPrint(error.message);
     } catch (error) {
       if (mounted) {
         // context.showSnackBar('Unexpected error occurred', isError: true);

--- a/lib/ui/screens/auth/widgets/register_form.dart
+++ b/lib/ui/screens/auth/widgets/register_form.dart
@@ -25,11 +25,11 @@ class RegisterForm extends StatelessWidget {
       if (name.trim() != '' && isFirst == true) {
         final user =
             User(id: '', fullName: name, balance: balance, inCloud: false);
-        int idGenerated = await userRepo.insertUser(user);
+        int idGenerated = await userRepo.upsertUser(user);
         await prefs.setInt('userId', idGenerated);
         await prefs.setBool('isFirstLaunch', false);
       }
-      await userRepo.getAllUsers();
+      // await userRepo.getAllUsers();
     } catch (e) {
       throw Exception(e);
     }

--- a/lib/ui/screens/new_entry_screen.dart
+++ b/lib/ui/screens/new_entry_screen.dart
@@ -2,10 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:pocket_union/Dao/sqlite/category_dao_sqlite.dart';
-import 'package:pocket_union/Dao/sqlite/revenue_dao_sqlite.dart';
+import 'package:pocket_union/Dao/sqlite/income_dao_sqlite.dart';
 import 'package:pocket_union/core/providers.dart';
 import 'package:pocket_union/domain/models/category.dart';
-import 'package:pocket_union/domain/models/income.dart';
+import 'package:pocket_union/dto/new_income_dto.dart';
 import 'package:pocket_union/ui/widgets/form_title.dart';
 import 'package:pocket_union/ui/widgets/input_with_button.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -88,10 +88,10 @@ class _NewEntryScreenState extends ConsumerState<NewEntryScreen> {
   }
 
   Future<void> _createEntry(
-      Map<String, String> values, RevenueDaoSqlite revRepo) async {
+      Map<String, String> values, IncomeDaoSqlite revRepo) async {
     final prefs = await SharedPreferences.getInstance();
     final idUser = prefs.getString('userId');
-    print(values);
+    debugPrint(values as String?);
     try {
       final name = values['nombre']!;
       final DateTime date =
@@ -99,17 +99,15 @@ class _NewEntryScreenState extends ConsumerState<NewEntryScreen> {
       final price = double.tryParse(values['precio']!);
       final description = values['descripcion'];
       if (name.trim() != '' && price! > 50) {
-        final revenue = Income(
-            id: '',
-            idUser: idUser!,
+        final income = NewIncomeDto(
+            amount: price,
             name: name,
-            date: date,
-            price: price,
-            description: description,
-            category: 2,
-            inCloud: false);
-        int idGenerated = await revRepo.insertRevenue(revenue);
-        print(idGenerated);
+            importanceLevel: 3,
+            categoryId: "",
+            isRecurring: false,
+            isReceived: false);
+        int idGenerated = await revRepo.insertRevenue(income);
+        debugPrint(idGenerated as String?);
       }
     } catch (e) {
       return;
@@ -134,7 +132,7 @@ class _NewEntryScreenState extends ConsumerState<NewEntryScreen> {
       List<Category> categoryList) async {
     Map<String, IconData> categories = {};
     for (var value in categoryList) {
-      final result = <String, IconData>{value.name: value.iconData};
+      final result = <String, IconData>{value.name: IconData(2)};
       categories.addEntries(result.entries);
     }
     return categories;

--- a/lib/ui/widgets/grid_background.dart
+++ b/lib/ui/widgets/grid_background.dart
@@ -16,15 +16,13 @@ class GridBackground extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      child: CustomPaint(
-        painter: GridPainter(
-          gridColor: gridColor,
-          gridSize: gridSize,
-          strokeWidth: strokeWidth,
-        ),
-        child: child,
+    return CustomPaint(
+      painter: GridPainter(
+        gridColor: gridColor,
+        gridSize: gridSize,
+        strokeWidth: strokeWidth,
       ),
+      child: child,
     );
   }
 }


### PR DESCRIPTION
Major refactor of the SQLite schema and related DAOs. Introduces a new normalized schema with profile, couple, category, expense, income, and goal tables, including sync status and improved foreign key relationships. Renames RevenueDaoSqlite to IncomeDaoSqlite and updates related providers and usages. Adds SyncStatus enum, UserPort abstraction, and NewUserDto. Updates Category model to use SyncStatus. Refactors user and income insertion logic to match new schema. Cleans up UI code to use new DAOs and DTOs.