### PR TITLE
Add category & income services, providers, UI

### DIFF
--- a/lib/Dao/sqlite/category_dao_sqlite.dart
+++ b/lib/Dao/sqlite/category_dao_sqlite.dart
@@ -95,4 +95,21 @@ class CategoryDaoSqlite extends CategoryPort {
     // TODO: implement createCategories
     throw UnimplementedError();
   }
+
+  @override
+  Future<List<Category>> getCategoriesByHost(CategoryHost host) async {
+    final db = await _dbHelper.database;
+    try {
+      final List<Map<String, dynamic>> maps = await db.query(
+        'category',
+        where: 'category_host = ? AND is_deleted = 0',
+        whereArgs: [host.value],
+      );
+      return List.generate(maps.length, (int i) {
+        return Category.fromMap(maps[i]);
+      });
+    } catch (e) {
+      throw Exception("Error al obtener categorías por host: $e");
+    }
+  }
 }

--- a/lib/Dao/sqlite/income_dao_sqlite.dart
+++ b/lib/Dao/sqlite/income_dao_sqlite.dart
@@ -1,15 +1,57 @@
 import 'package:pocket_union/Dao/sqlite/db_helper_sqlite.dart';
 import 'package:pocket_union/domain/models/income.dart';
+import 'package:pocket_union/domain/port/feat/income_port.dart';
 import 'package:pocket_union/dto/new_income_dto.dart';
 import 'package:sqflite/sqflite.dart';
 import 'package:uuid/uuid.dart';
 
-class IncomeDaoSqlite {
+class IncomeDaoSqlite implements IncomePort {
   final DbSqlite dbHelper;
   final _uuid = Uuid();
 
   IncomeDaoSqlite({required this.dbHelper});
 
+  @override
+  Future<String> createIncome(NewIncomeDto dto) async {
+    final db = await dbHelper.database;
+    final id = _uuid.v4();
+    final now = DateTime.now();
+    final income = Income(
+      id: id,
+      coupleId: dto.coupleId,
+      name: dto.name,
+      transactionDate: now,
+      description: dto.description,
+      amount: dto.amount,
+      categoryId: dto.categoryId,
+      isRecurring: dto.isRecurring,
+      isReceived: dto.isReceived,
+      createdAt: now,
+      userRecipientId: dto.userId,
+    );
+    await db.insert('income', income.toMap(),
+        conflictAlgorithm: ConflictAlgorithm.replace);
+    return id;
+  }
+
+  @override
+  Future<List<Income>> getAllIncomes() async {
+    final db = await dbHelper.database;
+    try {
+      final List<Map<String, dynamic>> maps = await db.query(
+        'income',
+        where: 'is_deleted = 0',
+        orderBy: 'transaction_date DESC',
+      );
+      return List.generate(maps.length, (int i) {
+        return Income.fromMap(maps[i]);
+      });
+    } catch (e) {
+      throw Exception("Error al obtener ingresos: $e");
+    }
+  }
+
+  /// Legacy method kept for backward compatibility
   Future<int> insertRevenue(NewIncomeDto revenueDto) async {
     final db = await dbHelper.database;
     final revenue = Income(
@@ -17,23 +59,9 @@ class IncomeDaoSqlite {
         name: revenueDto.name,
         transactionDate: DateTime.now(),
         amount: revenueDto.amount,
-        createdAt: DateTime.now(),
-        inCloud: false);
-    int id = await db.insert('revenue', revenue.toMap(),
+        createdAt: DateTime.now());
+    int id = await db.insert('income', revenue.toMap(),
         conflictAlgorithm: ConflictAlgorithm.replace);
     return id;
-  }
-
-  Future<List<Income>> getAllRevenues() async {
-    final db = await dbHelper.database;
-    try {
-      final List<Map<String, dynamic>> maps =
-          await db.query('revenue', orderBy: 'name ASC');
-      return List.generate(maps.length, (int i) {
-        return Income.fromMap(maps[i]);
-      });
-    } catch (e) {
-      throw Exception(e);
-    }
   }
 }

--- a/lib/core/providers.dart
+++ b/lib/core/providers.dart
@@ -6,7 +6,14 @@ import 'package:pocket_union/Dao/sqlite/db_helper_sqlite.dart';
 import 'package:pocket_union/Dao/sqlite/income_dao_sqlite.dart';
 import 'package:pocket_union/Dao/sqlite/user_dao_sqlite.dart';
 import 'package:pocket_union/core/services/auth/auth_service.dart';
+import 'package:pocket_union/core/services/features/category_service.dart';
+import 'package:pocket_union/core/services/features/income_service.dart';
+import 'package:pocket_union/domain/enum/category_host.dart';
+import 'package:pocket_union/domain/models/category.dart';
+import 'package:pocket_union/domain/models/income.dart';
 import 'package:pocket_union/domain/models/user.dart';
+import 'package:pocket_union/domain/port/feat/category_port.dart';
+import 'package:pocket_union/domain/port/feat/income_port.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
@@ -81,4 +88,51 @@ final authServiceProvider = FutureProvider<AuthPort>((ref) async {
 final currentUserProvider = FutureProvider<DomainUser?>((ref) async {
   final userDao = ref.watch(userDaoProvider);
   return await userDao.getCurrentUser();
+});
+
+// CategoryService provider (offline-first)
+final categoryServiceProvider = FutureProvider<CategoryPort>((ref) async {
+  final supabaseClient = await ref.watch(supabaseClientProvider.future);
+  final categoryDao = ref.watch(categoryDaoProvider);
+  return CategoryService(categoryDao, supabaseClient);
+});
+
+// IncomeService provider (offline-first)
+final incomeServiceProvider = FutureProvider<IncomePort>((ref) async {
+  final supabaseClient = await ref.watch(supabaseClientProvider.future);
+  final incomeDao = ref.watch(revenueDaoProvider);
+  return IncomeService(incomeDao, supabaseClient);
+});
+
+// Categorías filtradas por CategoryHost.income (offline-first con fallback)
+final incomeCategoriesProvider = FutureProvider<List<Category>>((ref) async {
+  try {
+    final categoryService = await ref.watch(categoryServiceProvider.future);
+    return categoryService.getCategoriesByHost(CategoryHost.income);
+  } catch (_) {
+    final categoryDao = ref.watch(categoryDaoProvider);
+    return categoryDao.getCategoriesByHost(CategoryHost.income);
+  }
+});
+
+// Todas las categorías (para la pantalla de listado)
+final allCategoriesProvider = FutureProvider<List<Category>>((ref) async {
+  try {
+    final categoryService = await ref.watch(categoryServiceProvider.future);
+    return categoryService.getAllCategories();
+  } catch (_) {
+    final categoryDao = ref.watch(categoryDaoProvider);
+    return categoryDao.getAllCategories();
+  }
+});
+
+// Todos los ingresos (para la pantalla de listado)
+final allIncomesProvider = FutureProvider<List<Income>>((ref) async {
+  try {
+    final incomeService = await ref.watch(incomeServiceProvider.future);
+    return incomeService.getAllIncomes();
+  } catch (_) {
+    final incomeDao = ref.watch(revenueDaoProvider);
+    return incomeDao.getAllIncomes();
+  }
 });

--- a/lib/core/services/auth/auth_service.dart
+++ b/lib/core/services/auth/auth_service.dart
@@ -40,6 +40,21 @@ class AuthService extends AuthPort {
       ]);
       debugPrint(userProfile.toString());
 
+      // Guardar coupleId en SharedPreferences
+      try {
+        final coupleRows = await _supabaseClient
+            .from('couple')
+            .select('id')
+            .or('user1_id.eq.${loginRes.user!.id},user2_id.eq.${loginRes.user!.id}')
+            .limit(1);
+        if (coupleRows.isNotEmpty) {
+          await _sharedPreferences.setString(
+              'coupleId', coupleRows.first['id']);
+        }
+      } catch (e) {
+        debugPrint('No se pudo obtener coupleId: $e');
+      }
+
       if (response.isNotEmpty) {
         debugPrint("Se creo correctamente ${response.toString()}");
       }

--- a/lib/core/services/features/category_service.dart
+++ b/lib/core/services/features/category_service.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/foundation.dart' hide Category;
+import 'package:pocket_union/domain/enum/category_host.dart';
+import 'package:pocket_union/domain/models/category.dart';
+import 'package:pocket_union/domain/port/feat/category_port.dart';
+import 'package:pocket_union/dto/new_category_dto.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class CategoryService implements CategoryPort {
+  final CategoryPort _categoryDao;
+  final SupabaseClient _supabaseClient;
+
+  CategoryService(this._categoryDao, this._supabaseClient);
+
+  @override
+  Future<String> createCategory(NewCategoryDto categoryDto) async {
+    final id = await _categoryDao.createCategory(categoryDto);
+
+    try {
+      await _supabaseClient.from('category').insert({
+        'id': id,
+        'couple_id': categoryDto.coupleId,
+        'name': categoryDto.name,
+        'icon': categoryDto.icon,
+        'short_description': categoryDto.shortDescription,
+        'color': categoryDto.color,
+        'category_host': categoryDto.host.value,
+        'created_at': DateTime.now().toIso8601String(),
+      });
+    } catch (e) {
+      // debugPrint('CategoryService: no se pudo sincronizar con Supabase: $e');
+    }
+
+    return id;
+  }
+
+  @override
+  Future<bool> deleteCategory(String idCategory) async {
+    return await _categoryDao.deleteCategory(idCategory);
+  }
+
+  @override
+  Future createDefaultCategories(String idCouple) async {
+    return await _categoryDao.createDefaultCategories(idCouple);
+  }
+
+  @override
+  Future deleteAllCategories() async {
+    return await _categoryDao.deleteAllCategories();
+  }
+
+  @override
+  Future<bool> createCategories(List<NewCategoryDto> categories) async {
+    return await _categoryDao.createCategories(categories);
+  }
+
+  @override
+  Future<List<Category>> getAllCategories() async {
+    return await _categoryDao.getAllCategories();
+  }
+
+  @override
+  Future<List<Category>> getCategoriesByHost(CategoryHost host) async {
+    return await _categoryDao.getCategoriesByHost(host);
+  }
+}

--- a/lib/core/services/features/income_service.dart
+++ b/lib/core/services/features/income_service.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/foundation.dart';
+import 'package:pocket_union/domain/models/income.dart';
+import 'package:pocket_union/domain/port/feat/income_port.dart';
+import 'package:pocket_union/dto/new_income_dto.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class IncomeService implements IncomePort {
+  final IncomePort _incomeDao;
+  final SupabaseClient _supabaseClient;
+
+  IncomeService(this._incomeDao, this._supabaseClient);
+
+  @override
+  Future<List<Income>> getAllIncomes() async {
+    return await _incomeDao.getAllIncomes();
+  }
+
+  @override
+  Future<String> createIncome(NewIncomeDto dto) async {
+    final id = await _incomeDao.createIncome(dto);
+
+    try {
+      final now = DateTime.now().toIso8601String();
+      await _supabaseClient.from('income').insert({
+        'id': id,
+        'couple_id': dto.coupleId,
+        'name': dto.name,
+        'transaction_date': now,
+        'description': dto.description,
+        'amount': (dto.amount * 100).round(),
+        'category_id': dto.categoryId,
+        'is_recurring': dto.isRecurring,
+        'is_received': dto.isReceived,
+        'created_at': now,
+        'user_recipient_id': dto.userId,
+      });
+    } catch (e) {
+      debugPrint('IncomeService: no se pudo sincronizar con Supabase: $e');
+    }
+
+    return id;
+  }
+}

--- a/lib/domain/models/category.dart
+++ b/lib/domain/models/category.dart
@@ -34,7 +34,7 @@ class Category {
       'color': color,
       'created_at': createdAt.toIso8601String(),
       'category_host': categoryHost.value,
-      'sync_status': syncStatus
+      'sync_status': syncStatus.value
     };
   }
 
@@ -48,7 +48,8 @@ class Category {
         color: map['color'],
         createdAt: DateTime.parse(map['created_at']),
         categoryHost: CategoryHost.fromString(map['category_host']),
-        syncStatus: map['sync_status']);
+        syncStatus: SyncStatus.fromString(
+            (map['sync_status'] as String? ?? 'pending').toUpperCase()));
   }
 
   Map<String, dynamic> toJson() {
@@ -74,6 +75,7 @@ class Category {
         color: json['color'],
         createdAt: DateTime.parse(json['created_at']),
         categoryHost: CategoryHost.fromString(json['category_host']),
-        syncStatus: json['sync_status']);
+        syncStatus: SyncStatus.fromString(
+            (json['sync_status'] as String? ?? 'pending').toUpperCase()));
   }
 }

--- a/lib/domain/models/income.dart
+++ b/lib/domain/models/income.dart
@@ -1,3 +1,5 @@
+import 'package:pocket_union/domain/enum/sync_status.dart';
+
 class Income {
   final String id;
   final String? coupleId;
@@ -11,7 +13,11 @@ class Income {
   final bool isReceived;
   final Map<String, dynamic>? receivedIn;
   final DateTime createdAt;
-  bool inCloud;
+
+  /// Quién recibió el dinero. null = ambos (NOSOTROS).
+  final String? userRecipientId;
+  SyncStatus syncStatus;
+  bool isDeleted;
 
   Income({
     required this.id,
@@ -26,7 +32,9 @@ class Income {
     this.isReceived = true,
     this.receivedIn,
     required this.createdAt,
-    required this.inCloud,
+    this.userRecipientId,
+    this.syncStatus = SyncStatus.pending,
+    this.isDeleted = false,
   });
 
   Map<String, dynamic> toMap() {
@@ -36,17 +44,20 @@ class Income {
       'name': name,
       'transaction_date': transactionDate.toIso8601String(),
       'description': description,
-      'amount': amount,
+      'amount': (amount * 100).round(),
       'category_id': categoryId,
       'is_recurring': isRecurring ? 1 : 0,
       'recurrence_interval': recurrenceInterval,
       'is_received': isReceived ? 1 : 0,
       'received_in': receivedIn,
       'created_at': createdAt.toIso8601String(),
-      'inCloud': inCloud ? 1 : 0,
+      'user_recipient_id': userRecipientId,
+      'sync_status': syncStatus.value,
+      'is_deleted': isDeleted ? 1 : 0,
     };
   }
 
+  /// Lee desde SQLite donde amount está almacenado en centavos.
   factory Income.fromMap(Map<String, dynamic> map) {
     return Income(
       id: map['id'],
@@ -54,14 +65,17 @@ class Income {
       name: map['name'],
       transactionDate: DateTime.parse(map['transaction_date']),
       description: map['description'],
-      amount: (map['amount'] as num).toDouble(),
+      amount: (map['amount'] as num).toDouble() / 100,
       categoryId: map['category_id'],
       isRecurring: map['is_recurring'] == 1,
       recurrenceInterval: map['recurrence_interval'],
       isReceived: map['is_received'] == 1,
       receivedIn: map['received_in'],
       createdAt: DateTime.parse(map['created_at']),
-      inCloud: map['inCloud'] == 1,
+      userRecipientId: map['user_recipient_id'],
+      syncStatus: SyncStatus.fromString(
+          (map['sync_status'] as String? ?? 'pending').toUpperCase()),
+      isDeleted: map['is_deleted'] == 1,
     );
   }
 
@@ -79,6 +93,7 @@ class Income {
       'is_received': isReceived,
       'received_in': receivedIn,
       'created_at': createdAt.toIso8601String(),
+      'user_recipient_id': userRecipientId,
     };
   }
 
@@ -96,7 +111,10 @@ class Income {
       isReceived: json['is_received'] ?? true,
       receivedIn: json['received_in'],
       createdAt: DateTime.parse(json['created_at']),
-      inCloud: json['inCloud'] == 1,
+      userRecipientId: json['user_recipient_id'],
+      syncStatus: SyncStatus.fromString(
+          (json['sync_status'] as String? ?? 'pending').toUpperCase()),
+      isDeleted: json['is_deleted'] == 1 || json['is_deleted'] == true,
     );
   }
 }

--- a/lib/domain/port/feat/category_port.dart
+++ b/lib/domain/port/feat/category_port.dart
@@ -1,3 +1,4 @@
+import 'package:pocket_union/domain/enum/category_host.dart';
 import 'package:pocket_union/domain/models/category.dart';
 import 'package:pocket_union/dto/new_category_dto.dart';
 
@@ -8,4 +9,5 @@ abstract class CategoryPort {
   Future deleteAllCategories();
   Future<bool> createCategories(List<NewCategoryDto> categories);
   Future<List<Category>> getAllCategories();
+  Future<List<Category>> getCategoriesByHost(CategoryHost host);
 }

--- a/lib/domain/port/feat/income_port.dart
+++ b/lib/domain/port/feat/income_port.dart
@@ -1,0 +1,7 @@
+import 'package:pocket_union/domain/models/income.dart';
+import 'package:pocket_union/dto/new_income_dto.dart';
+
+abstract class IncomePort {
+  Future<String> createIncome(NewIncomeDto dto);
+  Future<List<Income>> getAllIncomes();
+}

--- a/lib/dto/new_category_dto.dart
+++ b/lib/dto/new_category_dto.dart
@@ -4,7 +4,7 @@ import 'package:pocket_union/domain/models/category.dart';
 
 class NewCategoryDto {
   final String name;
-  final String coupleId;
+  String? coupleId;
   String? icon;
   String? shortDescription;
   String? color;
@@ -12,8 +12,8 @@ class NewCategoryDto {
 
   NewCategoryDto({
     required this.name,
-    required this.coupleId,
     required this.host,
+    this.coupleId,
     this.icon,
     this.shortDescription,
     this.color,
@@ -24,7 +24,7 @@ class NewCategoryDto {
     var status = isSync ? SyncStatus.pending : SyncStatus.synced;
     return Category(
         id: id,
-        coupleId: dto.coupleId,
+        coupleId: dto.coupleId ?? '',
         name: dto.name,
         createdAt: DateTime.now(),
         categoryHost: dto.host,

--- a/lib/dto/new_income_dto.dart
+++ b/lib/dto/new_income_dto.dart
@@ -1,23 +1,27 @@
 class NewIncomeDto {
   final String name;
   final double amount;
-  final int importanceLevel;
   String? description;
   final String categoryId;
   final bool isRecurring;
   Object? recurrenceInterval;
   final bool isReceived;
   Object? receivedIn;
+  String? coupleId;
+
+  /// null = NOSOTROS (ambos), valor = YO (solo ese usuario)
+  String? userId;
 
   NewIncomeDto({
     required this.amount,
     required this.name,
-    required this.importanceLevel,
     required this.categoryId,
     required this.isRecurring,
     required this.isReceived,
     this.description,
     this.recurrenceInterval,
     this.receivedIn,
+    this.coupleId,
+    this.userId,
   });
 }

--- a/lib/ui/router.dart
+++ b/lib/ui/router.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:pocket_union/ui/screens/auth/login_screen.dart';
 import 'package:pocket_union/ui/screens/auth/register_screen.dart';
+import 'package:pocket_union/ui/screens/categories/new_category_screen.dart';
 import 'package:pocket_union/ui/screens/categories_screen.dart';
 import 'package:pocket_union/ui/screens/history_expenses_screen.dart';
 import 'package:pocket_union/ui/screens/history_income_screen.dart';
@@ -20,6 +21,7 @@ class AppRoutes {
   static const String historyIncome = '/history-income';
   static const String missions = '/missions';
   static const String categories = '/categories';
+  static const String newCategory = '/new-category';
 
   static Map<String, WidgetBuilder> routes = {
     start: (context) => const StartScreen(),
@@ -31,5 +33,6 @@ class AppRoutes {
     historyIncome: (context) => const HistoryIncomeScreen(),
     missions: (context) => const MissionsScreen(),
     categories: (context) => const CategoriesScreen(),
+    newCategory: (context) => const NewCategoryScreen(),
   };
 }

--- a/lib/ui/screens/categories/categories_list_screen.dart
+++ b/lib/ui/screens/categories/categories_list_screen.dart
@@ -1,0 +1,196 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:pocket_union/core/providers.dart';
+import 'package:pocket_union/core/services/features/category_service.dart';
+import 'package:pocket_union/domain/enum/category_host.dart';
+import 'package:pocket_union/domain/models/category.dart' as domain;
+import 'package:pocket_union/domain/port/feat/category_port.dart';
+import 'package:pocket_union/ui/router.dart';
+
+class CategoriesListScreen extends ConsumerWidget {
+  const CategoriesListScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final categoriesAsync = ref.watch(allCategoriesProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Mis Categorías'),
+        backgroundColor: const Color.fromRGBO(46, 0, 76, 0.75),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () async {
+          await Navigator.pushNamed(context, AppRoutes.newCategory);
+          ref.invalidate(allCategoriesProvider);
+          ref.invalidate(incomeCategoriesProvider);
+        },
+        child: const Icon(Icons.add),
+      ),
+      body: categoriesAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (err, _) => Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Icon(Icons.error_outline, size: 48, color: Colors.red),
+              const SizedBox(height: 12),
+              Text('Error al cargar categorías: $err'),
+              const SizedBox(height: 12),
+              ElevatedButton(
+                onPressed: () => ref.invalidate(allCategoriesProvider),
+                child: const Text('Reintentar'),
+              ),
+            ],
+          ),
+        ),
+        data: (categories) {
+          if (categories.isEmpty) {
+            return Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Icon(Icons.category_outlined,
+                      size: 64, color: Colors.grey),
+                  const SizedBox(height: 16),
+                  const Text(
+                    'No hay categorías creadas',
+                    style: TextStyle(fontSize: 18, color: Colors.grey),
+                  ),
+                  const SizedBox(height: 16),
+                  ElevatedButton.icon(
+                    onPressed: () async {
+                      await Navigator.pushNamed(context, AppRoutes.newCategory);
+                      ref.invalidate(allCategoriesProvider);
+                      ref.invalidate(incomeCategoriesProvider);
+                    },
+                    icon: const Icon(Icons.add),
+                    label: const Text('Crear primera categoría'),
+                  ),
+                  ElevatedButton.icon(
+                    onPressed: () async {
+                      // await Navigator.pushNamed(context, AppRoutes.newCategory);
+                      ref.invalidate(allCategoriesProvider);
+                      ref.invalidate(incomeCategoriesProvider);
+                      final service =
+                          await ref.watch(categoryServiceProvider.future);
+                      await _createDefaultCategories(service);
+                    },
+                    icon: const Icon(Icons.add),
+                    label: const Text('Crear categorías por defecto'),
+                  ),
+                ],
+              ),
+            );
+          }
+
+          // Separar por host
+          final incomeCategories = categories
+              .where((c) => c.categoryHost == CategoryHost.income)
+              .toList();
+          final expenseCategories = categories
+              .where((c) => c.categoryHost == CategoryHost.expense)
+              .toList();
+
+          return RefreshIndicator(
+            onRefresh: () async {
+              ref.invalidate(allCategoriesProvider);
+            },
+            child: ListView(
+              padding: const EdgeInsets.symmetric(vertical: 8),
+              children: [
+                if (incomeCategories.isNotEmpty) ...[
+                  _buildSectionHeader(
+                      context, 'Ingresos', Icons.arrow_downward, Colors.green),
+                  ...incomeCategories.map((c) => _buildCategoryTile(c)),
+                ],
+                if (expenseCategories.isNotEmpty) ...[
+                  _buildSectionHeader(
+                      context, 'Gastos', Icons.arrow_upward, Colors.red),
+                  ...expenseCategories.map((c) => _buildCategoryTile(c)),
+                ],
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildSectionHeader(
+      BuildContext context, String title, IconData icon, Color color) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
+      child: Row(
+        children: [
+          Icon(icon, color: color, size: 20),
+          const SizedBox(width: 8),
+          Text(
+            title,
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                  color: color,
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCategoryTile(domain.Category category) {
+    final iconData = category.icon != null
+        ? IconData(int.parse(category.icon!), fontFamily: 'MaterialIcons')
+        : Icons.category;
+
+    final color = category.color != null
+        ? Color(int.parse(category.color!.replaceFirst('#', ''), radix: 16))
+        : Colors.grey;
+
+    return ListTile(
+      leading: CircleAvatar(
+        backgroundColor: color.withAlpha(30),
+        child: Icon(iconData, color: color),
+      ),
+      title: Text(category.name),
+      subtitle: category.shortDescription != null &&
+              category.shortDescription!.isNotEmpty
+          ? Text(
+              category.shortDescription!,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            )
+          : null,
+      trailing: _buildSyncBadge(category.syncStatus.value),
+    );
+  }
+
+  Widget _buildSyncBadge(String syncStatus) {
+    final IconData icon;
+    final Color color;
+
+    switch (syncStatus) {
+      case 'SYNCED':
+        icon = Icons.cloud_done;
+        color = Colors.green;
+      case 'PENDING':
+        icon = Icons.cloud_upload_outlined;
+        color = Colors.orange;
+      case 'CONFLICT':
+        icon = Icons.warning_amber;
+        color = Colors.red;
+      default:
+        icon = Icons.cloud_off;
+        color = Colors.grey;
+    }
+
+    return Icon(icon, color: color, size: 20);
+  }
+
+  Future<void> _createDefaultCategories(CategoryPort categoryService) async {
+    try {
+      await categoryService.createDefaultCategories("");
+    } catch (e) {
+      debugPrint(e.toString());
+    }
+  }
+}

--- a/lib/ui/screens/categories/new_category_screen.dart
+++ b/lib/ui/screens/categories/new_category_screen.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:pocket_union/ui/screens/categories/widgets/new_category_form.dart';
+import 'package:pocket_union/ui/widgets/form_title.dart';
+
+class NewCategoryScreen extends ConsumerWidget {
+  const NewCategoryScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Nueva Categoría'),
+        backgroundColor: const Color.fromRGBO(46, 0, 76, 0.75),
+      ),
+      body: const SafeArea(
+        child: SingleChildScrollView(
+          child: Column(
+            children: [
+              FormTitle(title: 'Crear categoría'),
+              NewCategoryForm(),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/screens/categories/widgets/new_category_form.dart
+++ b/lib/ui/screens/categories/widgets/new_category_form.dart
@@ -1,0 +1,330 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:pocket_union/core/providers.dart';
+import 'package:pocket_union/domain/enum/category_host.dart';
+import 'package:pocket_union/dto/new_category_dto.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class NewCategoryForm extends ConsumerStatefulWidget {
+  const NewCategoryForm({super.key});
+
+  @override
+  ConsumerState<NewCategoryForm> createState() => _NewCategoryFormState();
+}
+
+class _NewCategoryFormState extends ConsumerState<NewCategoryForm> {
+  final _formKey = GlobalKey<FormState>();
+  final _nameController = TextEditingController();
+  final _descriptionController = TextEditingController();
+
+  CategoryHost _selectedHost = CategoryHost.income;
+  IconData? _selectedIcon;
+  Color? _selectedColor;
+  bool _isSubmitting = false;
+
+  static const List<IconData> _availableIcons = [
+    Icons.work,
+    Icons.card_giftcard,
+    Icons.sell,
+    Icons.star,
+    Icons.attach_money,
+    Icons.account_balance,
+    Icons.savings,
+    Icons.trending_up,
+    Icons.shopping_cart,
+    Icons.restaurant,
+    Icons.local_gas_station,
+    Icons.home,
+    Icons.directions_car,
+    Icons.flight,
+    Icons.school,
+    Icons.health_and_safety,
+    Icons.sports_esports,
+    Icons.pets,
+    Icons.checkroom,
+    Icons.phone_android,
+  ];
+
+  static const List<Color> _availableColors = [
+    Color(0xFFF44336),
+    Color(0xFFE91E63),
+    Color(0xFF9C27B0),
+    Color(0xFF673AB7),
+    Color(0xFF3F51B5),
+    Color(0xFF2196F3),
+    Color(0xFF009688),
+    Color(0xFF4CAF50),
+    Color(0xFF8BC34A),
+    Color(0xFFFF9800),
+    Color(0xFFFF5722),
+    Color(0xFF795548),
+  ];
+
+  String _colorToHex(Color color) {
+    return '#${color.toARGB32().toRadixString(16).padLeft(8, '0').toUpperCase()}';
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _descriptionController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    if (!_formKey.currentState!.validate()) return;
+
+    if (_selectedIcon == null) {
+      _showSnackBar('Selecciona un icono para la categoría');
+      return;
+    }
+    if (_selectedColor == null) {
+      _showSnackBar('Selecciona un color para la categoría');
+      return;
+    }
+
+    setState(() => _isSubmitting = true);
+
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final coupleId = prefs.getString('coupleId');
+
+      final dto = NewCategoryDto(
+        name: _nameController.text.trim(),
+        host: _selectedHost,
+        coupleId: coupleId,
+        icon: _selectedIcon!.codePoint.toString(),
+        color: _colorToHex(_selectedColor!),
+        shortDescription: _descriptionController.text.trim().isEmpty
+            ? null
+            : _descriptionController.text.trim(),
+      );
+
+      try {
+        final service = await ref.read(categoryServiceProvider.future);
+        await service.createCategory(dto);
+      } catch (_) {
+        final dao = ref.read(categoryDaoProvider);
+        await dao.createCategory(dto);
+      }
+
+      ref.invalidate(incomeCategoriesProvider);
+      ref.invalidate(allCategoriesProvider);
+
+      if (!mounted) return;
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Categoría creada exitosamente'),
+          backgroundColor: Colors.green,
+        ),
+      );
+
+      Navigator.of(context).pop();
+    } catch (e) {
+      if (!mounted) return;
+      _showSnackBar('Error al crear la categoría: $e');
+    } finally {
+      if (mounted) setState(() => _isSubmitting = false);
+    }
+  }
+
+  void _showSnackBar(String message) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message)),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Form(
+        key: _formKey,
+        autovalidateMode: AutovalidateMode.onUnfocus,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            if (_selectedIcon != null && _selectedColor != null)
+              _buildPreview(),
+            const SizedBox(height: 16),
+
+            // --- Nombre ---
+            TextFormField(
+              controller: _nameController,
+              decoration: const InputDecoration(
+                labelText: 'Nombre de la categoría',
+                hintText: 'Ej: Salario, Comida, Transporte',
+                prefixIcon: Icon(Icons.label),
+              ),
+              maxLength: 50,
+              validator: (value) {
+                if (value == null || value.trim().isEmpty) {
+                  return 'El nombre es requerido';
+                }
+                if (value.trim().length < 2) {
+                  return 'Mínimo 2 caracteres';
+                }
+                return null;
+              },
+            ),
+            const SizedBox(height: 16),
+
+            // --- Tipo ---
+            Text('Tipo de categoría',
+                style: Theme.of(context).textTheme.titleSmall),
+            const SizedBox(height: 8),
+            SegmentedButton<CategoryHost>(
+              segments: const [
+                ButtonSegment(
+                  value: CategoryHost.income,
+                  label: Text('Ingreso'),
+                  icon: Icon(Icons.arrow_downward, color: Colors.green),
+                ),
+                ButtonSegment(
+                  value: CategoryHost.expense,
+                  label: Text('Gasto'),
+                  icon: Icon(Icons.arrow_upward, color: Colors.red),
+                ),
+              ],
+              selected: {_selectedHost},
+              onSelectionChanged: (s) =>
+                  setState(() => _selectedHost = s.first),
+            ),
+            const SizedBox(height: 24),
+
+            // --- Icono ---
+            Text('Icono', style: Theme.of(context).textTheme.titleSmall),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: _availableIcons.map((icon) {
+                final isSelected = _selectedIcon == icon;
+                return GestureDetector(
+                  onTap: () => setState(() => _selectedIcon = icon),
+                  child: Container(
+                    width: 48,
+                    height: 48,
+                    decoration: BoxDecoration(
+                      color: isSelected
+                          ? (_selectedColor ?? Theme.of(context).primaryColor)
+                              .withAlpha(50)
+                          : Colors.grey.withAlpha(30),
+                      borderRadius: BorderRadius.circular(12),
+                      border: isSelected
+                          ? Border.all(
+                              color: _selectedColor ??
+                                  Theme.of(context).primaryColor,
+                              width: 2)
+                          : null,
+                    ),
+                    child: Icon(icon,
+                        color: isSelected
+                            ? (_selectedColor ?? Theme.of(context).primaryColor)
+                            : Colors.grey),
+                  ),
+                );
+              }).toList(),
+            ),
+            const SizedBox(height: 24),
+
+            // --- Color ---
+            Text('Color', style: Theme.of(context).textTheme.titleSmall),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 10,
+              runSpacing: 10,
+              children: _availableColors.map((color) {
+                final isSelected = _selectedColor == color;
+                return GestureDetector(
+                  onTap: () => setState(() => _selectedColor = color),
+                  child: Container(
+                    width: 40,
+                    height: 40,
+                    decoration: BoxDecoration(
+                      color: color,
+                      shape: BoxShape.circle,
+                      border: isSelected
+                          ? Border.all(color: Colors.white, width: 3)
+                          : null,
+                      boxShadow: isSelected
+                          ? [
+                              BoxShadow(
+                                  color: color.withAlpha(150),
+                                  blurRadius: 8,
+                                  spreadRadius: 2)
+                            ]
+                          : null,
+                    ),
+                    child: isSelected
+                        ? const Icon(Icons.check, color: Colors.white, size: 20)
+                        : null,
+                  ),
+                );
+              }).toList(),
+            ),
+            const SizedBox(height: 24),
+
+            // --- Descripción ---
+            TextFormField(
+              controller: _descriptionController,
+              decoration: const InputDecoration(
+                labelText: 'Descripción (opcional)',
+                hintText: 'Breve descripción de la categoría',
+                prefixIcon: Icon(Icons.notes),
+              ),
+              maxLength: 120,
+              maxLines: 2,
+            ),
+            const SizedBox(height: 24),
+
+            // --- Submit ---
+            ElevatedButton.icon(
+              onPressed: _isSubmitting ? null : _submit,
+              icon: _isSubmitting
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2))
+                  : const Icon(Icons.save),
+              label: Text(_isSubmitting ? 'Guardando...' : 'Crear categoría'),
+              style: ElevatedButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(vertical: 14)),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPreview() {
+    return Center(
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+        decoration: BoxDecoration(
+          color: _selectedColor!.withAlpha(30),
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: _selectedColor!.withAlpha(100)),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(_selectedIcon, color: _selectedColor, size: 32),
+            const SizedBox(width: 12),
+            Text(
+              _nameController.text.isEmpty
+                  ? 'Vista previa'
+                  : _nameController.text,
+              style: TextStyle(
+                fontSize: 18,
+                fontWeight: FontWeight.w600,
+                color: _selectedColor,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -28,13 +28,13 @@ class _HomeScreenState extends State<HomeScreen> {
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
           switch (indexScreen) {
-            0 => NewEntryScreen(),
+            0 => Expanded(child: NewEntryScreen()),
             1 => Expanded(
                   child: StartHeroWidget(
                 name1: "1",
                 name2: "2",
               )),
-            2 => NewOutScreen(),
+            2 => Expanded(child: NewOutScreen()),
             int() => throw UnimplementedError(),
           }
         ],

--- a/lib/ui/screens/transactions/in/new_entry_screen.dart
+++ b/lib/ui/screens/transactions/in/new_entry_screen.dart
@@ -1,120 +1,41 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:pocket_union/Dao/sqlite/income_dao_sqlite.dart';
 import 'package:pocket_union/core/providers.dart';
-import 'package:pocket_union/domain/models/category.dart';
-import 'package:pocket_union/dto/new_income_dto.dart';
 import 'package:pocket_union/ui/screens/transactions/in/widgets/new_entry_form.dart';
 import 'package:pocket_union/ui/widgets/form_title.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
-class NewEntryScreen extends ConsumerStatefulWidget {
+class NewEntryScreen extends ConsumerWidget {
   const NewEntryScreen({super.key});
 
   @override
-  ConsumerState<NewEntryScreen> createState() => _NewEntryScreenState();
-}
+  Widget build(BuildContext context, WidgetRef ref) {
+    final categoriesAsync = ref.watch(incomeCategoriesProvider);
 
-class _NewEntryScreenState extends ConsumerState<NewEntryScreen> {
-  // List<String> _categoryNames = [];
-  // Map<String, IconData> _categoryIcons = {};
-  // Map<String, String> _categoriesId = {};
-  bool _loadingCategories = true;
-
-  @override
-  void initState() {
-    super.initState();
-    _loadCategories();
-  }
-
-  Future<void> _loadCategories() async {
-    try {
-      final categories = await _getAllCategories();
-      final names = await _getAllCategoriesNames(categories);
-      // final icons = await _getAllCategoriesIcons(categories);
-      // final ids = await _getAllCategoriesId(categories);
-      // setState(() {
-      //   _categoryNames = names;
-      //   _categoryIcons = icons;
-      //   _categoriesId = ids;
-      //   _loadingCategories = false;
-      // });
-      debugPrint(names.toString());
-      debugPrint("hola");
-    } catch (e) {
-      _loadingCategories = false;
-      throw Exception(e);
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(children: [
-      FormTitle(title: "Agregar entrada de dinero"),
-      _loadingCategories ? const CircularProgressIndicator() : NewEntryForm()
-    ]);
-  }
-
-  Future<void> _createEntry(
-      Map<String, String> values, IncomeDaoSqlite revRepo) async {
-    final prefs = await SharedPreferences.getInstance();
-    final idUser = prefs.getString('userId');
-    debugPrint(values as String?);
-    try {
-      final name = values['nombre']!;
-      final DateTime date =
-          DateTime.tryParse(values['fecha']!) ?? DateTime.now();
-      final price = double.tryParse(values['precio']!);
-      final description = values['descripcion'];
-      if (name.trim() != '' && price! > 50) {
-        final income = NewIncomeDto(
-            amount: price,
-            name: name,
-            importanceLevel: 3,
-            categoryId: "",
-            isRecurring: false,
-            isReceived: false);
-        int idGenerated = await revRepo.insertRevenue(income);
-        debugPrint(idGenerated as String?);
-      }
-    } catch (e) {
-      return;
-    }
-  }
-
-  Future<List<Category>> _getAllCategories() async {
-    try {
-      var catRepo = ref.read(categoryDaoProvider);
-      List<Category> categoryList = await catRepo.getAllCategories();
-      return categoryList;
-    } catch (e) {
-      return [];
-    }
-  }
-
-  Future<List<String>> _getAllCategoriesNames(
-      List<Category> categoryList) async {
-    return categoryList.map((category) => category.name).toList();
-  }
-
-  Future<Map<String, IconData>> _getAllCategoriesIcons(
-      List<Category> categoryList) async {
-    Map<String, IconData> categories = {};
-    for (var value in categoryList) {
-      final result = <String, IconData>{value.name: IconData(2)};
-      categories.addEntries(result.entries);
-    }
-    return categories;
-  }
-
-  Future<Map<String, String>> _getAllCategoriesId(
-      List<Category> categoryList) async {
-    Map<String, String> categories = {};
-
-    for (var value in categoryList) {
-      final result = <String, String>{value.name: value.id};
-      categories.addEntries(result.entries);
-    }
-    return categories;
+    return categoriesAsync.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (err, _) => Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(Icons.error_outline, size: 48, color: Colors.red),
+            const SizedBox(height: 12),
+            Text('Error al cargar categorías: $err'),
+            const SizedBox(height: 12),
+            ElevatedButton(
+              onPressed: () => ref.invalidate(incomeCategoriesProvider),
+              child: const Text('Reintentar'),
+            ),
+          ],
+        ),
+      ),
+      data: (categories) => SingleChildScrollView(
+        child: Column(
+          children: [
+            const FormTitle(title: "Agregar entrada de dinero"),
+            NewEntryForm(categories: categories),
+          ],
+        ),
+      ),
+    );
   }
 }

--- a/lib/ui/screens/transactions/in/widgets/new_entry_form.dart
+++ b/lib/ui/screens/transactions/in/widgets/new_entry_form.dart
@@ -1,32 +1,228 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:pocket_union/core/providers.dart';
+import 'package:pocket_union/domain/models/category.dart';
+import 'package:pocket_union/dto/new_income_dto.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class NewEntryForm extends ConsumerStatefulWidget {
-  const NewEntryForm({super.key});
+  final List<Category> categories;
+  const NewEntryForm({super.key, required this.categories});
 
   @override
-  ConsumerState<ConsumerStatefulWidget> createState() => _NewEntryFormState();
+  ConsumerState<NewEntryForm> createState() => _NewEntryFormState();
 }
 
 class _NewEntryFormState extends ConsumerState<NewEntryForm> {
+  final _formKey = GlobalKey<FormState>();
+  final _nameController = TextEditingController();
+  final _amountController = TextEditingController();
+  final _descriptionController = TextEditingController();
+
+  String? _selectedCategoryId;
+  bool _isReceived = true; // YO por defecto
+  bool _isSubmitting = false;
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _amountController.dispose();
+    _descriptionController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    if (!_formKey.currentState!.validate()) return;
+
+    setState(() => _isSubmitting = true);
+
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final coupleId = prefs.getString('coupleId');
+      final userId = prefs.getString('idUser');
+
+      final dto = NewIncomeDto(
+        name: _nameController.text.trim(),
+        amount: double.parse(_amountController.text.trim()),
+        categoryId: _selectedCategoryId ?? '',
+        isRecurring: false,
+        isReceived: _isReceived,
+        description: _descriptionController.text.trim().isEmpty
+            ? null
+            : _descriptionController.text.trim(),
+        coupleId: coupleId,
+        // YO = userId, NOSOTROS = null
+        userId: _isReceived ? userId : null,
+      );
+
+      // Offline-first: intenta el service, fallback al DAO
+      try {
+        final service = await ref.read(incomeServiceProvider.future);
+        await service.createIncome(dto);
+      } catch (_) {
+        final dao = ref.read(revenueDaoProvider);
+        await dao.createIncome(dto);
+      }
+
+      ref.invalidate(allIncomesProvider);
+
+      if (!mounted) return;
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Ingreso creado exitosamente'),
+          backgroundColor: Colors.green,
+        ),
+      );
+
+      // Limpiar formulario
+      _nameController.clear();
+      _amountController.clear();
+      _descriptionController.clear();
+      setState(() {
+        _selectedCategoryId = null;
+        _isReceived = true;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Error al crear ingreso: $e')),
+      );
+    } finally {
+      if (mounted) setState(() => _isSubmitting = false);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
-    return Form(
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Form(
+        key: _formKey,
+        autovalidateMode: AutovalidateMode.onUnfocus,
         child: Column(
-      children: [
-        Text("Nombre de el ingreso"),
-        TextFormField(),
-        Text("¿Cuanto entro?"),
-        TextFormField(),
-        Switch(
-            value: false,
-            onChanged: (value) {
-              debugPrint(value.toString());
-              value = !value;
-            }),
-        CupertinoSwitch(value: true, onChanged: (_) {})
-      ],
-    ));
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            // --- Nombre ---
+            TextFormField(
+              controller: _nameController,
+              decoration: const InputDecoration(
+                labelText: 'Nombre del ingreso',
+                hintText: 'Ej: Salario, Freelance, Regalo',
+                prefixIcon: Icon(Icons.label),
+              ),
+              validator: (value) {
+                if (value == null || value.trim().isEmpty) {
+                  return 'El nombre es requerido';
+                }
+                return null;
+              },
+            ),
+            const SizedBox(height: 16),
+
+            // --- Monto ---
+            TextFormField(
+              controller: _amountController,
+              decoration: const InputDecoration(
+                labelText: 'Monto',
+                hintText: '0.00',
+                prefixIcon: Icon(Icons.attach_money),
+              ),
+              keyboardType:
+                  const TextInputType.numberWithOptions(decimal: true),
+              validator: (value) {
+                if (value == null || value.trim().isEmpty) {
+                  return 'El monto es requerido';
+                }
+                final parsed = double.tryParse(value.trim());
+                if (parsed == null || parsed <= 0) {
+                  return 'Ingresa un monto válido mayor a 0';
+                }
+                return null;
+              },
+            ),
+            const SizedBox(height: 16),
+
+            // --- Categoría ---
+            DropdownButtonFormField<String>(
+              value: _selectedCategoryId,
+              decoration: const InputDecoration(
+                labelText: 'Categoría',
+                prefixIcon: Icon(Icons.category),
+              ),
+              items: widget.categories.map((cat) {
+                return DropdownMenuItem<String>(
+                  value: cat.id,
+                  child: Text(cat.name),
+                );
+              }).toList(),
+              onChanged: (value) {
+                setState(() => _selectedCategoryId = value);
+              },
+              validator: (value) {
+                if (value == null || value.isEmpty) {
+                  return 'Selecciona una categoría';
+                }
+                return null;
+              },
+            ),
+            const SizedBox(height: 16),
+
+            // --- ¿Quién recibe? ---
+            Text(
+              '¿Quién recibe el ingreso?',
+              style: Theme.of(context).textTheme.titleSmall,
+            ),
+            const SizedBox(height: 8),
+            SegmentedButton<bool>(
+              segments: const [
+                ButtonSegment(
+                  value: true,
+                  label: Text('YO'),
+                  icon: Icon(Icons.person),
+                ),
+                ButtonSegment(
+                  value: false,
+                  label: Text('NOSOTROS'),
+                  icon: Icon(Icons.people),
+                ),
+              ],
+              selected: {_isReceived},
+              onSelectionChanged: (selection) {
+                setState(() => _isReceived = selection.first);
+              },
+            ),
+            const SizedBox(height: 16),
+
+            // --- Descripción ---
+            TextFormField(
+              controller: _descriptionController,
+              decoration: const InputDecoration(
+                labelText: 'Descripción (opcional)',
+                prefixIcon: Icon(Icons.notes),
+              ),
+              maxLines: 2,
+            ),
+            const SizedBox(height: 24),
+
+            // --- Submit ---
+            ElevatedButton.icon(
+              onPressed: _isSubmitting ? null : _submit,
+              icon: _isSubmitting
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.save),
+              label: Text(_isSubmitting ? 'Guardando...' : 'Registrar ingreso'),
+              style: ElevatedButton.styleFrom(
+                padding: const EdgeInsets.symmetric(vertical: 14),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }

--- a/test/services/category_service_test.dart
+++ b/test/services/category_service_test.dart
@@ -1,0 +1,169 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:pocket_union/core/services/features/category_service.dart';
+import 'package:pocket_union/domain/enum/category_host.dart';
+import 'package:pocket_union/domain/enum/sync_status.dart';
+import 'package:pocket_union/domain/models/category.dart';
+import 'package:pocket_union/domain/port/feat/category_port.dart';
+import 'package:pocket_union/dto/new_category_dto.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'category_service_test.mocks.dart';
+
+@GenerateMocks([CategoryPort, SupabaseClient])
+void main() {
+  late CategoryService categoryService;
+  late MockCategoryPort mockCategoryDao;
+  late MockSupabaseClient mockSupabaseClient;
+
+  final incomeCategory = Category(
+    id: 'cat-uuid-1',
+    coupleId: 'couple-1',
+    name: 'Salario',
+    createdAt: DateTime(2024, 1, 1),
+    categoryHost: CategoryHost.income,
+    syncStatus: SyncStatus.pending,
+  );
+
+  final expenseCategory = Category(
+    id: 'cat-uuid-2',
+    coupleId: 'couple-1',
+    name: 'Comida',
+    createdAt: DateTime(2024, 1, 1),
+    categoryHost: CategoryHost.expense,
+    syncStatus: SyncStatus.pending,
+  );
+
+  setUp(() {
+    mockCategoryDao = MockCategoryPort();
+    mockSupabaseClient = MockSupabaseClient();
+    categoryService = CategoryService(mockCategoryDao, mockSupabaseClient);
+  });
+
+  group('CategoryService - getAllCategories', () {
+    test('retorna lista de categorías desde el DAO local', () async {
+      when(mockCategoryDao.getAllCategories())
+          .thenAnswer((_) async => [incomeCategory, expenseCategory]);
+
+      final result = await categoryService.getAllCategories();
+
+      expect(result, hasLength(2));
+      expect(result.first.name, 'Salario');
+      verify(mockCategoryDao.getAllCategories()).called(1);
+    });
+
+    test('retorna lista vacía cuando no hay categorías', () async {
+      when(mockCategoryDao.getAllCategories()).thenAnswer((_) async => []);
+
+      final result = await categoryService.getAllCategories();
+
+      expect(result, isEmpty);
+      verify(mockCategoryDao.getAllCategories()).called(1);
+    });
+
+    test('propaga excepción del DAO', () async {
+      when(mockCategoryDao.getAllCategories()).thenThrow(Exception('DB error'));
+
+      expect(
+        () => categoryService.getAllCategories(),
+        throwsException,
+      );
+    });
+  });
+
+  group('CategoryService - getCategoriesByHost', () {
+    test('retorna solo categorías del host indicado (INCOME)', () async {
+      when(mockCategoryDao.getCategoriesByHost(CategoryHost.income))
+          .thenAnswer((_) async => [incomeCategory]);
+
+      final result =
+          await categoryService.getCategoriesByHost(CategoryHost.income);
+
+      expect(result, hasLength(1));
+      expect(result.first.categoryHost, CategoryHost.income);
+      expect(result.first.name, 'Salario');
+      verify(mockCategoryDao.getCategoriesByHost(CategoryHost.income))
+          .called(1);
+    });
+
+    test('retorna solo categorías del host indicado (EXPENSE)', () async {
+      when(mockCategoryDao.getCategoriesByHost(CategoryHost.expense))
+          .thenAnswer((_) async => [expenseCategory]);
+
+      final result =
+          await categoryService.getCategoriesByHost(CategoryHost.expense);
+
+      expect(result, hasLength(1));
+      expect(result.first.categoryHost, CategoryHost.expense);
+      expect(result.first.name, 'Comida');
+      verify(mockCategoryDao.getCategoriesByHost(CategoryHost.expense))
+          .called(1);
+    });
+
+    test('retorna lista vacía si no hay categorías del host', () async {
+      when(mockCategoryDao.getCategoriesByHost(CategoryHost.income))
+          .thenAnswer((_) async => []);
+
+      final result =
+          await categoryService.getCategoriesByHost(CategoryHost.income);
+
+      expect(result, isEmpty);
+      verify(mockCategoryDao.getCategoriesByHost(CategoryHost.income))
+          .called(1);
+    });
+
+    test('propaga excepción del DAO', () async {
+      when(mockCategoryDao.getCategoriesByHost(any))
+          .thenThrow(Exception('DB error'));
+
+      expect(
+        () => categoryService.getCategoriesByHost(CategoryHost.income),
+        throwsException,
+      );
+    });
+  });
+
+  group('CategoryService - createCategory', () {
+    final newCategoryDto = NewCategoryDto(
+      name: 'Freelance',
+      host: CategoryHost.income,
+      coupleId: 'couple-1',
+    );
+
+    test('inserta en SQLite y devuelve el ID generado', () async {
+      const generatedId = 'new-uuid-123';
+      when(mockCategoryDao.createCategory(any))
+          .thenAnswer((_) async => generatedId);
+      // Supabase falla en silencio (offline-first)
+      when(mockSupabaseClient.from(any)).thenThrow(Exception('offline'));
+
+      final result = await categoryService.createCategory(newCategoryDto);
+
+      expect(result, generatedId);
+      verify(mockCategoryDao.createCategory(any)).called(1);
+    });
+
+    test('retorna ID aunque falle la sincronización con Supabase', () async {
+      const generatedId = 'new-uuid-456';
+      when(mockCategoryDao.createCategory(any))
+          .thenAnswer((_) async => generatedId);
+      when(mockSupabaseClient.from(any)).thenThrow(Exception('Network error'));
+
+      final result = await categoryService.createCategory(newCategoryDto);
+
+      expect(result, generatedId);
+      verify(mockCategoryDao.createCategory(any)).called(1);
+    });
+
+    test('lanza excepción si el DAO falla', () async {
+      when(mockCategoryDao.createCategory(any))
+          .thenThrow(Exception('SQLite error'));
+
+      expect(
+        () => categoryService.createCategory(newCategoryDto),
+        throwsException,
+      );
+    });
+  });
+}

--- a/test/services/income_service_test.dart
+++ b/test/services/income_service_test.dart
@@ -1,0 +1,179 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:pocket_union/core/services/features/income_service.dart';
+import 'package:pocket_union/domain/enum/sync_status.dart';
+import 'package:pocket_union/domain/models/income.dart';
+import 'package:pocket_union/domain/port/feat/income_port.dart';
+import 'package:pocket_union/dto/new_income_dto.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'income_service_test.mocks.dart';
+
+@GenerateMocks([IncomePort, SupabaseClient])
+void main() {
+  late IncomeService incomeService;
+  late MockIncomePort mockIncomeDao;
+  late MockSupabaseClient mockSupabaseClient;
+
+  final testIncome = Income(
+    id: 'income-uuid-1',
+    name: 'Sueldo',
+    transactionDate: DateTime(2024, 1, 15),
+    amount: 1500.0,
+    createdAt: DateTime(2024, 1, 15),
+    categoryId: 'cat-1',
+    isReceived: true,
+    userRecipientId: 'user-1',
+    syncStatus: SyncStatus.pending,
+  );
+
+  setUp(() {
+    mockIncomeDao = MockIncomePort();
+    mockSupabaseClient = MockSupabaseClient();
+    incomeService = IncomeService(mockIncomeDao, mockSupabaseClient);
+  });
+
+  group('IncomeService - getAllIncomes', () {
+    test('retorna lista de ingresos desde el DAO local', () async {
+      when(mockIncomeDao.getAllIncomes()).thenAnswer((_) async => [testIncome]);
+
+      final result = await incomeService.getAllIncomes();
+
+      expect(result, hasLength(1));
+      expect(result.first.name, 'Sueldo');
+      verify(mockIncomeDao.getAllIncomes()).called(1);
+    });
+
+    test('retorna lista vacía cuando no hay ingresos', () async {
+      when(mockIncomeDao.getAllIncomes()).thenAnswer((_) async => []);
+
+      final result = await incomeService.getAllIncomes();
+
+      expect(result, isEmpty);
+      verify(mockIncomeDao.getAllIncomes()).called(1);
+    });
+
+    test('propaga excepción del DAO', () async {
+      when(mockIncomeDao.getAllIncomes()).thenThrow(Exception('DB error'));
+
+      expect(
+        () => incomeService.getAllIncomes(),
+        throwsException,
+      );
+    });
+  });
+
+  group('IncomeService - createIncome', () {
+    final newIncomeDto = NewIncomeDto(
+      name: 'Sueldo enero',
+      amount: 1500.00,
+      categoryId: 'cat-uuid-1',
+      isReceived: true,
+      userId: 'user-uuid-1',
+      description: 'Pago mensual',
+      coupleId: 'couple-1',
+    );
+
+    test('inserta en SQLite y devuelve el ID generado', () async {
+      const generatedId = 'income-uuid-new';
+      when(mockIncomeDao.createIncome(any))
+          .thenAnswer((_) async => generatedId);
+      // Supabase falla en silencio (offline-first)
+      when(mockSupabaseClient.from(any)).thenThrow(Exception('offline'));
+
+      final result = await incomeService.createIncome(newIncomeDto);
+
+      expect(result, generatedId);
+      verify(mockIncomeDao.createIncome(any)).called(1);
+    });
+
+    test('retorna ID aunque falle la sincronización con Supabase', () async {
+      const generatedId = 'income-uuid-offline';
+      when(mockIncomeDao.createIncome(any))
+          .thenAnswer((_) async => generatedId);
+      when(mockSupabaseClient.from(any)).thenThrow(Exception('Network error'));
+
+      final result = await incomeService.createIncome(newIncomeDto);
+
+      expect(result, generatedId);
+      verify(mockIncomeDao.createIncome(any)).called(1);
+    });
+
+    test('lanza excepción si el DAO falla', () async {
+      when(mockIncomeDao.createIncome(any))
+          .thenThrow(Exception('SQLite error'));
+
+      expect(
+        () => incomeService.createIncome(newIncomeDto),
+        throwsException,
+      );
+    });
+
+    test('isReceived=true (solo yo) pasa userId al DAO', () async {
+      when(mockIncomeDao.createIncome(any)).thenAnswer((_) async => 'id-me');
+      when(mockSupabaseClient.from(any)).thenThrow(Exception('offline'));
+
+      final dto = NewIncomeDto(
+        name: 'Bono',
+        amount: 500.0,
+        categoryId: 'cat-2',
+        isReceived: true,
+        userId: 'user-1',
+      );
+
+      await incomeService.createIncome(dto);
+
+      final captured = verify(mockIncomeDao.createIncome(captureAny))
+          .captured
+          .single as NewIncomeDto;
+      expect(captured.isReceived, isTrue);
+      expect(captured.userId, 'user-1');
+      expect(captured.name, 'Bono');
+    });
+
+    test('isReceived=false (ambos) pasa userId null al DAO', () async {
+      when(mockIncomeDao.createIncome(any)).thenAnswer((_) async => 'id-both');
+      when(mockSupabaseClient.from(any)).thenThrow(Exception('offline'));
+
+      final dto = NewIncomeDto(
+        name: 'Dividendos',
+        amount: 2000.0,
+        categoryId: 'cat-3',
+        isReceived: false,
+        userId: null,
+      );
+
+      await incomeService.createIncome(dto);
+
+      final captured = verify(mockIncomeDao.createIncome(captureAny))
+          .captured
+          .single as NewIncomeDto;
+      expect(captured.isReceived, isFalse);
+      expect(captured.userId, isNull);
+    });
+
+    test('coupleId se pasa correctamente al DAO', () async {
+      when(mockIncomeDao.createIncome(any))
+          .thenAnswer((_) async => 'id-couple');
+      when(mockSupabaseClient.from(any)).thenThrow(Exception('offline'));
+
+      final dto = NewIncomeDto(
+        name: 'Ingreso pareja',
+        amount: 3000.0,
+        categoryId: 'cat-4',
+        isReceived: false,
+        userId: null,
+        coupleId: 'couple-uuid-1',
+      );
+
+      await incomeService.createIncome(dto);
+
+      final captured = verify(mockIncomeDao.createIncome(captureAny))
+          .captured
+          .single as NewIncomeDto;
+      expect(captured.coupleId, 'couple-uuid-1');
+      expect(captured.userId, isNull);
+    });
+  });
+}


### PR DESCRIPTION
Introduce offline-first feature layer and UI for categories and incomes. Adds CategoryService and IncomeService (implementing new feature ports), new income_port and extended category_port, and updates DAOs: IncomeDaoSqlite now implements IncomePort (createIncome/getAllIncomes) and CategoryDaoSqlite adds getCategoriesByHost. Domain models and DTOs updated (Income now tracks userRecipientId, syncStatus, isDeleted and stores amounts in cents; Category syncStatus handling improved; NewCategoryDto/NewIncomeDto fields adjusted). Providers were added to expose services and lists (all/income categories and incomes) with service-first, DAO-fallback behavior. New UI screens and widgets: categories list, new category screen/form, and revamped new-entry form/screen; router and home layout adjusted. AuthService persists coupleId to SharedPreferences. Tests added for CategoryService (and income service test stub). Overall enables offline-first sync and richer category/income UX and data model changes.